### PR TITLE
Info panel fixes and adding scrollbars

### DIFF
--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1347,6 +1347,7 @@ void player::disp_info()
         draw_tip( w_tip, *this, race, ctxt );
     } );
 
+    // STATS
     catacurses::window w_stats;
     catacurses::window w_stats_border;
     border_helper::border_info &border_stats = borders.add_border();
@@ -1371,6 +1372,7 @@ void player::disp_info()
         draw_stats_tab( w_stats, *this, line, curtab );
     } );
 
+    // TRAITS
     unsigned int trait_win_size_y = 0;
     catacurses::window w_traits;
     catacurses::window w_traits_border;
@@ -1393,6 +1395,7 @@ void player::disp_info()
         draw_traits_tab( w_traits, line, curtab, traitslist, trait_win_size_y );
     } );
 
+    // BIONICS
     unsigned int bionics_win_size_y = 0;
     catacurses::window w_bionics;
     catacurses::window w_bionics_border;
@@ -1417,6 +1420,7 @@ void player::disp_info()
         draw_bionics_tab( w_bionics, *this, line, curtab, bionicslist, bionics_win_size_y );
     } );
 
+    // ENCUMBRANCE
     catacurses::window w_encumb;
     catacurses::window w_encumb_border;
     border_helper::border_info &border_encumb = borders.add_border();
@@ -1434,6 +1438,7 @@ void player::disp_info()
         draw_encumbrance_tab( w_encumb, *this, line, curtab );
     } );
 
+    // EFFECTS
     catacurses::window w_effects;
     catacurses::window w_effects_border;
     border_helper::border_info &border_effects = borders.add_border();
@@ -1454,6 +1459,7 @@ void player::disp_info()
         draw_effects_tab( w_effects, line, curtab, effect_name_and_text, effect_win_size_y );
     } );
 
+    // PROFICIENCIES
     unsigned int proficiency_win_size_y = 0;
     const point profstart = point( grid_width * 2 + 2, infooffsetybottom + effect_win_size_y + 1 );
     catacurses::window w_proficiencies;
@@ -1479,6 +1485,7 @@ void player::disp_info()
         draw_proficiencies_tab( w_proficiencies, line, *this, curtab );
     } );
 
+    // SKILLS
     unsigned int skill_win_size_y = 0;
     catacurses::window w_skills;
     catacurses::window w_skills_border;
@@ -1505,6 +1512,7 @@ void player::disp_info()
         draw_skills_tab( w_skills, *this, line, curtab, skillslist, skill_win_size_y );
     } );
 
+    // info panel
     catacurses::window w_info;
     catacurses::window w_info_border;
     border_helper::border_info &border_info = borders.add_border();
@@ -1526,6 +1534,7 @@ void player::disp_info()
                           traitslist, bionicslist, effect_name_and_text, skillslist );
     } );
 
+    // SPEED
     catacurses::window w_speed;
     catacurses::window w_speed_border;
     border_helper::border_info &border_speed = borders.add_border();

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1266,7 +1266,9 @@ void player::disp_info()
         }
     }
 
-    const unsigned int effect_win_size_y = 1 + static_cast<unsigned>( effect_name_and_text.size() );
+    const unsigned int effect_win_size_y_max = 1 + static_cast<unsigned>( effect_name_and_text.size() );
+    const unsigned int proficiency_win_size_y_max = 1 + static_cast<unsigned>
+            ( display_proficiencies().size() );
 
     std::vector<trait_id> traitslist = get_mutations( false );
     std::sort( traitslist.begin(), traitslist.end(), trait_display_sort );
@@ -1453,12 +1455,21 @@ void player::disp_info()
         draw_encumbrance_tab( w_encumb, *this, line, curtab );
     } );
 
+    // EFFECTS & PROFICIENCIES
+    const std::pair<unsigned int, unsigned int> effect_and_proficiency_height =
+        calculate_shared_column_win_height(
+            static_cast<unsigned>( TERMY ) - infooffsetybottom,
+            effect_win_size_y_max,
+            proficiency_win_size_y_max
+        );
     // EFFECTS
+    unsigned int effect_win_size_y = 0;
     catacurses::window w_effects;
     catacurses::window w_effects_border;
     border_helper::border_info &border_effects = borders.add_border();
     ui_adaptor ui_effects;
     ui_effects.on_screen_resize( [&]( ui_adaptor & ui_effects ) {
+        effect_win_size_y = effect_and_proficiency_height.first;
         w_effects = catacurses::newwin( effect_win_size_y, grid_width,
                                         point( grid_width * 2 + 2, infooffsetybottom ) );
         w_effects_border = catacurses::newwin( effect_win_size_y + 1, grid_width + 2,
@@ -1476,15 +1487,13 @@ void player::disp_info()
 
     // PROFICIENCIES
     unsigned int proficiency_win_size_y = 0;
-    const point profstart = point( grid_width * 2 + 2, infooffsetybottom + effect_win_size_y + 1 );
     catacurses::window w_proficiencies;
     catacurses::window w_proficiencies_border;
     border_helper::border_info &border_proficiencies = borders.add_border();
     ui_adaptor ui_proficiencies;
     ui_proficiencies.on_screen_resize( [&]( ui_adaptor & ui_proficiencies ) {
-        const unsigned int maxy = static_cast<unsigned>( TERMY );
-        proficiency_win_size_y = std::min( display_proficiencies().size(),
-                                           static_cast<size_t>( maxy - ( infooffsetybottom + effect_win_size_y ) ) ) + 1;
+        const point profstart = point( grid_width * 2 + 2, infooffsetybottom + effect_win_size_y + 1 );
+        proficiency_win_size_y = effect_and_proficiency_height.second;
         w_proficiencies = catacurses::newwin( proficiency_win_size_y, grid_width,
                                               profstart );
         w_proficiencies_border = catacurses::newwin( proficiency_win_size_y + 1, grid_width + 2,

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -121,6 +121,30 @@ static std::pair<size_t, size_t> subindex_around_cursor(
     return std::make_pair( slice_start, slice_end );
 }
 
+static void draw_scrollbar(
+    const size_t list_lenght,
+    const size_t height,
+    const size_t width,
+    const size_t height_offset,
+    const size_t range_first,
+    const catacurses::window &win
+)
+/**
+ * Draw scrollbar if scrollable.
+ */
+{
+    if( list_lenght > height ) {
+        scrollbar()
+        .offset_x( width )
+        .offset_y( height_offset )
+        .content_size( list_lenght )
+        .viewport_pos( range_first )
+        .viewport_size( height )
+        .scroll_to_last( false )
+        .apply( win );
+    }
+}
+
 void Character::print_encumbrance( const catacurses::window &win, const int line,
                                    const item *const selected_clothing ) const
 {
@@ -130,8 +154,8 @@ void Character::print_encumbrance( const catacurses::window &win, const int line
 
     // width/height excluding title & scrollbar
     const int height = getmaxy( win ) - 1;
-    bool draw_scrollbar = height < static_cast<int>( bps.size() );
-    const int width = getmaxx( win ) - ( draw_scrollbar ? 1 : 0 );
+    const bool do_draw_scrollbar = height < static_cast<int>( bps.size() );
+    const int width = getmaxx( win ) - ( do_draw_scrollbar ? 1 : 0 );
     // index of the first printed bodypart from `bps`
     const int firstline = clamp( line - height / 2, 0, std::max( 0,
                                  static_cast<int>( bps.size() ) - height ) );
@@ -177,16 +201,7 @@ void Character::print_encumbrance( const catacurses::window &win, const int line
                    temperature_print_rescaling( get_part_temp_conv( bp ) ) );
     }
 
-    if( draw_scrollbar ) {
-        scrollbar().
-        offset_x( width ).
-        offset_y( 1 ).
-        content_size( bps.size() ).
-        viewport_pos( firstline ).
-        viewport_size( height ).
-        scroll_to_last( false ).
-        apply( win );
-    }
+    draw_scrollbar( bps.size(), height, width, 1, firstline, win );
 }
 
 static std::string swim_cost_text( float moves )
@@ -329,9 +344,8 @@ static void draw_proficiencies_tab( const catacurses::window &win, const unsigne
     const nc_color title_color = focused ? h_light_gray : c_light_gray;
     center_print( win, 0, title_color, _( title_PROFICIENCIES ) );
 
-    const int height = getmaxy( win ) - 1;
-    const int width = getmaxx( win ) - 1;
-    bool draw_scrollbar = profs.size() > static_cast<size_t>( height );
+    const size_t height = getmaxy( win ) - 1;
+    const size_t width = getmaxx( win ) - 1;
     const std::pair<const size_t, const size_t> range = subindex_around_cursor( profs.size(), height,
             line, focused );
     for( size_t i = range.first; i < range.second; ++i ) {
@@ -349,18 +363,7 @@ static void draw_proficiencies_tab( const catacurses::window &win, const unsigne
         const nc_color col = focused && i == line ? hilite( cur.color ) : cur.color;
         fold_and_print( win, point( 0, 1 + i - range.first ), width, col, name );
     }
-
-    if( draw_scrollbar ) {
-        scrollbar()
-        .offset_x( width )
-        .offset_y( 1 )
-        .content_size( profs.size() )
-        .viewport_pos( range.first )
-        .viewport_size( height )
-        .scroll_to_last( false )
-        .apply( win );
-    }
-
+    draw_scrollbar( profs.size(), height, width, 1, range.first, win );
     wnoutrefresh( win );
 }
 
@@ -571,16 +574,17 @@ static void draw_encumbrance_info( const catacurses::window &w_info,
 
 static void draw_traits_tab( const catacurses::window &w_traits,
                              const unsigned int line, const player_display_tab curtab,
-                             const std::vector<trait_id> &traitslist,
-                             const size_t trait_win_size_y )
+                             const std::vector<trait_id> &traitslist )
 {
     werase( w_traits );
     const bool is_current_tab = curtab == player_display_tab::traits;
     const nc_color title_col = is_current_tab ? h_light_gray : c_light_gray;
     center_print( w_traits, 0, title_col, _( title_TRAITS ) );
 
+    const size_t height = getmaxy( w_traits ) - 1;
+    const size_t width = getmaxx( w_traits ) - 1;
     const std::pair<const size_t, const size_t> range = subindex_around_cursor( traitslist.size(),
-            trait_win_size_y - 1, line, is_current_tab );
+            height, line, is_current_tab );
 
     for( size_t i = range.first; i < range.second; i++ ) {
         const auto &mdata = traitslist[i].obj();
@@ -588,6 +592,7 @@ static void draw_traits_tab( const catacurses::window &w_traits,
         trim_and_print( w_traits, point( 1, static_cast<int>( 1 + i - range.first ) ),
                         getmaxx( w_traits ) - 1, is_current_tab && i == line ? hilite( color ) : color, mdata.name() );
     }
+    draw_scrollbar( traitslist.size(), height, width, 1, range.first, w_traits );
     wnoutrefresh( w_traits );
 }
 
@@ -606,7 +611,7 @@ static void draw_traits_info( const catacurses::window &w_info, const unsigned i
 
 static void draw_bionics_tab( const catacurses::window &w_bionics,
                               const player &you, const unsigned int line, const player_display_tab curtab,
-                              const std::vector<bionic> &bionicslist, const size_t bionics_win_size_y )
+                              const std::vector<bionic> &bionicslist )
 {
     werase( w_bionics );
     const bool is_current_tab = curtab == player_display_tab::bionics;
@@ -629,14 +634,17 @@ static void draw_bionics_tab( const catacurses::window &w_bionics,
                     string_format( _( "Power: <color_light_blue>%1$d %2$s</color>"
                                       " / <color_light_blue>%3$d kJ</color>" ),
                                    power_amount, power_unit, units::to_kilojoule( you.get_max_power_level() ) ) );
+    const size_t height = getmaxy( w_bionics ) - 2;
+    const size_t width = getmaxx( w_bionics ) - 1;
     const std::pair<const size_t, const size_t> range = subindex_around_cursor( bionicslist.size(),
-            bionics_win_size_y - 2, line, is_current_tab );
+            height, line, is_current_tab );
 
     for( size_t i = range.first; i < range.second; i++ ) {
         trim_and_print( w_bionics, point( 1, static_cast<int>( 2 + i - range.first ) ),
                         getmaxx( w_bionics ) - 1, is_current_tab &&
                         i == line ? hilite( c_white ) : c_white, "%s", bionicslist[i].info().name );
     }
+    draw_scrollbar( bionicslist.size(), height, width, 2, range.first, w_bionics );
     wnoutrefresh( w_bionics );
 }
 
@@ -654,22 +662,24 @@ static void draw_bionics_info( const catacurses::window &w_info, const unsigned 
 
 static void draw_effects_tab( const catacurses::window &w_effects,
                               const unsigned int line, const player_display_tab curtab,
-                              const std::vector<std::pair<std::string, std::string>> &effect_name_and_text,
-                              const size_t effect_win_size_y )
+                              const std::vector<std::pair<std::string, std::string>> &effect_name_and_text )
 {
     werase( w_effects );
     const bool is_current_tab = curtab == player_display_tab::effects;
     const nc_color title_col = is_current_tab ? h_light_gray : c_light_gray;
     center_print( w_effects, 0, title_col, _( title_EFFECTS ) );
 
+    const size_t height = getmaxy( w_effects ) - 1;
+    const size_t width = getmaxx( w_effects ) - 1;
     const std::pair<const size_t, const size_t> range = subindex_around_cursor(
-                effect_name_and_text.size(), effect_win_size_y - 1, line, is_current_tab );
+                effect_name_and_text.size(), height, line, is_current_tab );
 
     for( size_t i = range.first; i < range.second; i++ ) {
         trim_and_print( w_effects, point( 0, static_cast<int>( 1 + i - range.first ) ),
                         getmaxx( w_effects ) - 1, is_current_tab &&
                         i == line ? h_light_gray : c_light_gray, effect_name_and_text[i].first );
     }
+    draw_scrollbar( effect_name_and_text.size(), height, width, 1, range.first, w_effects );
     wnoutrefresh( w_effects );
 }
 
@@ -1379,7 +1389,7 @@ void player::disp_info()
     ui_traits.on_redraw( [&]( const ui_adaptor & ) {
         borders.draw_border( w_traits_border );
         wnoutrefresh( w_traits_border );
-        draw_traits_tab( w_traits, line, curtab, traitslist, trait_win_size_y );
+        draw_traits_tab( w_traits, line, curtab, traitslist );
     } );
 
     // BIONICS
@@ -1404,7 +1414,7 @@ void player::disp_info()
     ui_bionics.on_redraw( [&]( const ui_adaptor & ) {
         borders.draw_border( w_bionics_border );
         wnoutrefresh( w_bionics_border );
-        draw_bionics_tab( w_bionics, *this, line, curtab, bionicslist, bionics_win_size_y );
+        draw_bionics_tab( w_bionics, *this, line, curtab, bionicslist );
     } );
 
     // ENCUMBRANCE
@@ -1452,7 +1462,7 @@ void player::disp_info()
     ui_effects.on_redraw( [&]( const ui_adaptor & ) {
         borders.draw_border( w_effects_border );
         wnoutrefresh( w_effects_border );
-        draw_effects_tab( w_effects, line, curtab, effect_name_and_text, effect_win_size_y );
+        draw_effects_tab( w_effects, line, curtab, effect_name_and_text );
     } );
 
     // PROFICIENCIES

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -96,6 +96,31 @@ static std::vector<std::pair<bodypart_id, bool>> list_and_combine_bps( const Cha
     return bps;
 }
 
+static std::pair<size_t, size_t> subindex_around_cursor(
+    const size_t list_lenght,
+    const size_t available_space,
+    const size_t cursor_pos,
+    const bool focused
+)
+/**
+ * Return indexes [start, end) that should be displayed from list long `list_lenght`,
+ * given that cursor is at position `cursor_pos` and we have `available_space` spaces.
+ *
+ * Example:
+ * list_lenght = 6, available_space = 3, cursor_pos = 2, focused = true;
+ * so choose 3 from indexes [0, 1, 2, 3, 4, 5]
+ * return {1, 4}
+ */
+{
+    if( !focused || list_lenght <= available_space ) {
+        return std::make_pair( 0, std::min( available_space, list_lenght ) );
+    }
+    size_t slice_start = std::max( 0, int( cursor_pos ) - int( available_space ) / 2 );
+    slice_start = std::min( slice_start, list_lenght - available_space );
+    size_t slice_end = slice_start + available_space;
+    return std::make_pair( slice_start, slice_end );
+}
+
 void Character::print_encumbrance( const catacurses::window &win, const int line,
                                    const item *const selected_clothing ) const
 {
@@ -556,31 +581,14 @@ static void draw_traits_tab( const catacurses::window &w_traits,
     const nc_color title_col = is_current_tab ? h_light_gray : c_light_gray;
     center_print( w_traits, 0, title_col, _( title_TRAITS ) );
 
-    size_t min = 0;
-    size_t max = 0;
+    const std::pair<const size_t, const size_t> range = subindex_around_cursor( traitslist.size(),
+            trait_win_size_y - 1, line, is_current_tab );
 
-    if( !is_current_tab || line <= ( trait_win_size_y - 2 ) / 2 ) {
-        min = 0;
-        max = trait_win_size_y - 1;
-        if( traitslist.size() < max ) {
-            max = traitslist.size();
-        }
-    } else if( line >= traitslist.size() - trait_win_size_y / 2 ) {
-        min = ( traitslist.size() < trait_win_size_y - 1 ? 0 : traitslist.size() - trait_win_size_y + 1 );
-        max = traitslist.size();
-    } else {
-        min = line - ( trait_win_size_y - 2 ) / 2;
-        max = line + ( trait_win_size_y + 1 ) / 2;
-        if( traitslist.size() < max ) {
-            max = traitslist.size();
-        }
-    }
-
-    for( size_t i = min; i < max; i++ ) {
+    for( size_t i = range.first; i < range.second; i++ ) {
         const auto &mdata = traitslist[i].obj();
         const nc_color color = mdata.get_display_color();
-        trim_and_print( w_traits, point( 1, static_cast<int>( 1 + i - min ) ), getmaxx( w_traits ) - 1,
-                        is_current_tab && i == line ? hilite( color ) : color, mdata.name() );
+        trim_and_print( w_traits, point( 1, static_cast<int>( 1 + i - range.first ) ),
+                        getmaxx( w_traits ) - 1, is_current_tab && i == line ? hilite( color ) : color, mdata.name() );
     }
     wnoutrefresh( w_traits );
 }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -629,27 +629,13 @@ static void draw_bionics_tab( const catacurses::window &w_bionics,
                     string_format( _( "Power: <color_light_blue>%1$d %2$s</color>"
                                       " / <color_light_blue>%3$d kJ</color>" ),
                                    power_amount, power_unit, units::to_kilojoule( you.get_max_power_level() ) ) );
+    const std::pair<const size_t, const size_t> range = subindex_around_cursor( bionicslist.size(),
+            bionics_win_size_y - 2, line, is_current_tab );
 
-    const size_t useful_y = bionics_win_size_y - 2;
-    const size_t half_y = useful_y / 2;
-
-    size_t min = 0;
-    size_t max = 0;
-
-    if( !is_current_tab || line <= half_y ) { // near the top
-        min = 0;
-        max = std::min( bionicslist.size(), useful_y );
-    } else if( line >= bionicslist.size() - half_y ) { // near the bottom
-        min = ( bionicslist.size() <= useful_y ? 0 : bionicslist.size() - useful_y );
-        max = bionicslist.size();
-    } else { // scrolling
-        min = line - half_y;
-        max = std::min( bionicslist.size(), line + useful_y - half_y );
-    }
-
-    for( size_t i = min; i < max; i++ ) {
-        trim_and_print( w_bionics, point( 1, static_cast<int>( 2 + i - min ) ), getmaxx( w_bionics ) - 1,
-                        is_current_tab && i == line ? hilite( c_white ) : c_white, "%s", bionicslist[i].info().name );
+    for( size_t i = range.first; i < range.second; i++ ) {
+        trim_and_print( w_bionics, point( 1, static_cast<int>( 2 + i - range.first ) ),
+                        getmaxx( w_bionics ) - 1, is_current_tab &&
+                        i == line ? hilite( c_white ) : c_white, "%s", bionicslist[i].info().name );
     }
     wnoutrefresh( w_bionics );
 }
@@ -676,33 +662,13 @@ static void draw_effects_tab( const catacurses::window &w_effects,
     const nc_color title_col = is_current_tab ? h_light_gray : c_light_gray;
     center_print( w_effects, 0, title_col, _( title_EFFECTS ) );
 
-    const size_t half_y = ( effect_win_size_y - 1 ) / 2;
+    const std::pair<const size_t, const size_t> range = subindex_around_cursor(
+                effect_name_and_text.size(), effect_win_size_y - 1, line, is_current_tab );
 
-    size_t min = 0;
-    size_t max = 0;
-
-    const size_t actual_size = effect_name_and_text.size();
-
-    if( !is_current_tab || line <= half_y ) {
-        min = 0;
-        max = effect_win_size_y - 1;
-        if( actual_size < max ) {
-            max = actual_size;
-        }
-    } else if( line >= actual_size - half_y ) {
-        min = ( actual_size < effect_win_size_y - 1 ? 0 : actual_size - effect_win_size_y + 1 );
-        max = actual_size;
-    } else {
-        min = line - half_y;
-        max = line - half_y + effect_win_size_y - 1;
-        if( actual_size < max ) {
-            max = actual_size;
-        }
-    }
-
-    for( size_t i = min; i < max; i++ ) {
-        trim_and_print( w_effects, point( 0, static_cast<int>( 1 + i - min ) ), getmaxx( w_effects ) - 1,
-                        is_current_tab && i == line ? h_light_gray : c_light_gray, effect_name_and_text[i].first );
+    for( size_t i = range.first; i < range.second; i++ ) {
+        trim_and_print( w_effects, point( 0, static_cast<int>( 1 + i - range.first ) ),
+                        getmaxx( w_effects ) - 1, is_current_tab &&
+                        i == line ? h_light_gray : c_light_gray, effect_name_and_text[i].first );
     }
     wnoutrefresh( w_effects );
 }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1307,14 +1307,12 @@ void player::disp_info()
     // Post-humanity trumps your pre-Cataclysm life
     // Unless you have a custom profession.
     std::string race;
-    if( custom_profession.empty() ) {
-        if( crossed_threshold() ) {
-            for( const trait_id &mut : get_mutations() ) {
-                const mutation_branch &mdata = mut.obj();
-                if( mdata.threshold ) {
-                    race = mdata.name();
-                    break;
-                }
+    if( custom_profession.empty() && crossed_threshold() ) {
+        for( const trait_id &mut : get_mutations() ) {
+            const mutation_branch &mdata = mut.obj();
+            if( mdata.threshold ) {
+                race = mdata.name();
+                break;
             }
         }
     }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1152,6 +1152,36 @@ static bool handle_player_display_action( player &you, unsigned int &line,
     return done;
 }
 
+static std::pair<unsigned int, unsigned int> calculate_shared_column_win_height
+/**
+ * Calculate max allowed height of two windows sharing column space.
+ */
+(
+    const unsigned int available_height,
+    const unsigned int first_win_size_y_max,
+    const unsigned int second_win_size_y_max
+)
+{
+    unsigned int first_win_size_y = first_win_size_y_max;
+    unsigned int second_win_size_y = second_win_size_y_max;
+    if( ( second_win_size_y_max + 1 + first_win_size_y_max ) > available_height ) {
+        // maximum space for either window if they're both the same size
+        unsigned max_shared_y = ( available_height - 1 ) / 2;
+        if( std::min( second_win_size_y_max, first_win_size_y_max ) > max_shared_y ) {
+            // both are larger than the shared size
+            second_win_size_y = max_shared_y;
+            first_win_size_y = available_height - 1 - second_win_size_y;
+        } else if( first_win_size_y_max <= max_shared_y ) {
+            // first window is less than the shared size, so give space to second window
+            second_win_size_y = available_height - 1 - first_win_size_y_max;
+        } else {
+            // second window is less than the shared size
+            first_win_size_y = available_height - 1 - second_win_size_y;
+        }
+    }
+    return std::make_pair( first_win_size_y, second_win_size_y );
+}
+
 void player::disp_info()
 {
     std::vector<std::pair<std::string, std::string>> effect_name_and_text;
@@ -1271,28 +1301,6 @@ void player::disp_info()
     const unsigned int infooffsetytop = grid_height + 2;
     unsigned int infooffsetybottom = infooffsetytop + 1 + info_win_size_y;
 
-    const auto calculate_trait_and_bionic_height = [&]() {
-        const unsigned int maxy = static_cast<unsigned>( TERMY );
-        unsigned int trait_win_size_y = trait_win_size_y_max;
-        unsigned int bionics_win_size_y = bionics_win_size_y_max;
-        if( ( bionics_win_size_y_max + 1 + trait_win_size_y_max + infooffsetybottom ) > maxy ) {
-            // maximum space for either window if they're both the same size
-            unsigned max_shared_y = ( maxy - infooffsetybottom - 1 ) / 2;
-            if( std::min( bionics_win_size_y_max, trait_win_size_y_max ) > max_shared_y ) {
-                // both are larger than the shared size
-                bionics_win_size_y = max_shared_y;
-                trait_win_size_y = maxy - infooffsetybottom - 1 - bionics_win_size_y;
-            } else if( trait_win_size_y_max <= max_shared_y ) {
-                // trait window is less than the shared size, so give space to bionics
-                bionics_win_size_y = maxy - infooffsetybottom - 1 - trait_win_size_y_max;
-            } else {
-                // bionics window is less than the shared size
-                trait_win_size_y = maxy - infooffsetybottom - 1 - bionics_win_size_y;
-            }
-        }
-        return std::make_pair( trait_win_size_y, bionics_win_size_y );
-    };
-
     // Print name and header
     // Post-humanity trumps your pre-Cataclysm life
     // Unless you have a custom profession.
@@ -1372,6 +1380,13 @@ void player::disp_info()
         draw_stats_tab( w_stats, *this, line, curtab );
     } );
 
+    // TRAITS & BIONICS
+    const std::pair<unsigned int, unsigned int> trait_and_bionic_height =
+        calculate_shared_column_win_height(
+            static_cast<unsigned>( TERMY ) - infooffsetybottom,
+            trait_win_size_y_max,
+            bionics_win_size_y_max
+        );
     // TRAITS
     unsigned int trait_win_size_y = 0;
     catacurses::window w_traits;
@@ -1379,7 +1394,7 @@ void player::disp_info()
     border_helper::border_info &border_traits = borders.add_border();
     ui_adaptor ui_traits;
     ui_traits.on_screen_resize( [&]( ui_adaptor & ui_traits ) {
-        trait_win_size_y = calculate_trait_and_bionic_height().first;
+        trait_win_size_y = trait_and_bionic_height.first;
         w_traits = catacurses::newwin( trait_win_size_y, grid_width,
                                        point( grid_width + 1, infooffsetybottom ) );
         w_traits_border = catacurses::newwin( trait_win_size_y + 1, grid_width + 1,
@@ -1402,7 +1417,7 @@ void player::disp_info()
     border_helper::border_info &border_bionics = borders.add_border();
     ui_adaptor ui_bionics;
     ui_bionics.on_screen_resize( [&]( ui_adaptor & ui_bionics ) {
-        bionics_win_size_y = calculate_trait_and_bionic_height().second;
+        bionics_win_size_y = trait_and_bionic_height.second;
         w_bionics = catacurses::newwin( bionics_win_size_y, grid_width,
                                         point( grid_width + 1,
                                                infooffsetybottom + trait_win_size_y + 1 ) );

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -325,18 +325,16 @@ static void draw_proficiencies_tab( const catacurses::window &win, const unsigne
 {
     werase( win );
     const std::vector<display_proficiency> profs = guy.display_proficiencies();
-    bool focused = curtab == player_display_tab::proficiencies;
+    const bool focused = curtab == player_display_tab::proficiencies;
     const nc_color title_color = focused ? h_light_gray : c_light_gray;
     center_print( win, 0, title_color, _( title_PROFICIENCIES ) );
+
     const int height = getmaxy( win ) - 1;
     const int width = getmaxx( win ) - 1;
     bool draw_scrollbar = profs.size() > static_cast<size_t>( height );
-    int y = 1;
-    int start = draw_scrollbar ? line : 0;
-    for( size_t i = start; i < profs.size(); ++i ) {
-        if( y > height ) {
-            break;
-        }
+    const std::pair<const size_t, const size_t> range = subindex_around_cursor( profs.size(), height,
+            line, focused );
+    for( size_t i = range.first; i < range.second; ++i ) {
         std::string name;
         const display_proficiency &cur = profs[i];
         if( !cur.known && cur.id->can_learn() ) {
@@ -349,7 +347,7 @@ static void draw_proficiencies_tab( const catacurses::window &win, const unsigne
             name = trim_by_length( cur.id->name(), width );
         }
         const nc_color col = focused && i == line ? hilite( cur.color ) : cur.color;
-        y += fold_and_print( win, point( 0, y ), width, col, name );
+        fold_and_print( win, point( 0, 1 + i - range.first ), width, col, name );
     }
 
     if( draw_scrollbar ) {
@@ -357,7 +355,7 @@ static void draw_proficiencies_tab( const catacurses::window &win, const unsigne
         .offset_x( width )
         .offset_y( 1 )
         .content_size( profs.size() )
-        .viewport_pos( line )
+        .viewport_pos( range.first )
         .viewport_size( height )
         .scroll_to_last( false )
         .apply( win );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
Category must be one of these: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N. Or replace the whole line with just the word None for no changelog entry.
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #50851,
While fixing this issue I found (and often fixed) other issues:

- [x] EFFECTS tab has priority over PROFICIENCIES tab.
- [x] PROFICIENCIES tab has disgusting scrolling & is scrolling with others (while it's not selected).
- [x] Tabs TRAITS, BIONICS, EFFECTS are missing scrollbar.
- [ ] Left side of the BIONICS tab doesn't have a border (not fixed).
- [ ] TRAITS & BIONIC tabs don't use `...` (not fixed)

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Made similar code into functions. I might have overdone it in the case of `static void draw_scrollbar`.

Merged features that were in some tabs, but not all. This fixed off by one error causing #50851.

Some refactoring.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Since the scrollbar was only on one tab, remove it. But the scrollbar is good, so I fixed it there and added elsewhere.


<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Made save with lots of effects, bionic traits, mutations & proficiencies. Scrolling works, scrollbars too, everything is accounted for (nothing is under screen as was in #50851).

#### Additional context

I discovered two bugs I didn't fix

Before, with some fixed bugs:
(not shown: #50851)
![master, fixed](https://user-images.githubusercontent.com/13402666/130011242-536a1e0f-5791-4161-80b7-bc4476fb375f.png)

Before, disgusting scrolling:
![image](https://user-images.githubusercontent.com/13402666/130011643-4b46de33-6578-4b0b-9829-795c4c4ad964.png)


After, with left bugs:
![unfixed](https://user-images.githubusercontent.com/13402666/130010473-f160a48d-d839-4eb3-bd28-b1ead318dea2.png)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
